### PR TITLE
Reseptikirjan esimerkkikoodin päivitys

### DIFF
--- a/source/part9.html.erb
+++ b/source/part9.html.erb
@@ -2467,7 +2467,7 @@ mittaukset: [-10, -4, 5]
     System.out.println(resepti);
     
     Resepti toinen = kirja.haeNimella("leivos");
-    System.out.println(resepti);
+    System.out.println(toinen);
   <% end %>
 
   


### PR DESCRIPTION
Korvattu jälkimmäisen println():n sisältö muuttujalla "toinen" jota siinä pitäisikin käyttää esimerkkitulostuksen saavuttamiseksi.